### PR TITLE
Added support to set/get variant values and add variant values to JSONArray

### DIFF
--- a/Source/JsonDataObjects.pas
+++ b/Source/JsonDataObjects.pas
@@ -508,6 +508,7 @@ type
     procedure Add(AValue: Boolean); overload;
     procedure Add(const AValue: TJsonArray); overload;
     procedure Add(const AValue: TJsonObject); overload;
+    procedure Add(const AValue: Variant); overload;
     function AddArray: TJsonArray;
     function AddObject: TJsonObject; overload;
     procedure AddObject(const Value: TJsonObject); overload; inline; // makes it easier to add "null"
@@ -3132,6 +3133,14 @@ var
 begin
   Data := AddItem;
   Data.Value := AValue;
+end;
+
+procedure TJsonArray.Add(const AValue: Variant);
+var
+  Data: PJsonDataValue;
+begin
+  Data := AddItem;
+  Data.VariantValue := AValue;
 end;
 
 function TJsonArray.AddArray: TJsonArray;


### PR DESCRIPTION
Hi, I added property VariantValue to TJsonDataValue and TJsonDataValueHelper, so now you can do:
```
var
  v: variant;
begin
  v := jsonobject['my name'].VariantValue; 
  jsonobject['my name'].VariantValue := v;

  jsonarray.Add(v);
end;
```

Please take a look and let me know I you don't like somethig.
I hope you can add in your code.

Regards
Christian