### PR TITLE
Consider dates without Zulu/timezone as local

### DIFF
--- a/Source/JsonDataObjects.pas
+++ b/Source/JsonDataObjects.pas
@@ -1574,7 +1574,7 @@ begin
           P := ParseDateTimePart(P + 1, MSec, 3);
       end;
       Result := Result + EncodeTime(Hour, Min, Sec, MSec);
-      if P^ <> 'Z' then
+      if (P^ <> 'Z') and (P^ <> #0) then
       begin
         if (P^ = '+') or (P^ = '-') then
         begin

--- a/UnitTest/TestJsonDataObjects.pas
+++ b/UnitTest/TestJsonDataObjects.pas
@@ -1225,6 +1225,7 @@ begin
   TJsonBaseObject.JSONToDateTime('2009-01-01T12:00:00+0100');
   TJsonBaseObject.JSONToDateTime('2015-02-14T22:58+01:00');
   TJsonBaseObject.JSONToDateTime('2015-02-14T22:58+0100');
+  CheckNotEquals(0, TJsonBaseObject.JSONToDateTime('2015-02-14T22:58'));
 end;
 
 procedure TestTJsonBaseObject.TestEmptyString;


### PR DESCRIPTION
Not sure if you agree with the change in behaviour, but here's a pull request in case you do:

We had issues with a webservice which returns datetimes without the 'Z' indicator or a timezone offset. Officially it seems to be allowed, though it is unspecified how it should be interpreted. Since we can't fix the third party service, I changed JsonDataObjects to regard it as a local time instead of returning 0.