### PR TITLE
Added dspec file for dpm support

### DIFF
--- a/ahausladen.JsonDataObjects.dspec
+++ b/ahausladen.JsonDataObjects.dspec
@@ -1,0 +1,86 @@
+{
+  "metadata": {
+    "id": "Ahausladen.JsonDataObjects",
+    "version": "0.0.1",
+    "description": "Json Parser for D2009 or later",
+    "authors": "Andreas Hausladen",
+    "projectUrl": "https://github.com/ahausladen/JsonDataObjects",
+    "license": "MIT",
+    "copyright": "Andreas Hausladen and contributors",
+    "tags": "json parser"
+  },
+  "targetPlatforms": [
+    {
+      "compiler": "XE2",
+      "platforms": "Win32, Win64",
+      "template": "default"
+    },
+    {
+      "compiler": "XE3",
+      "platforms": "Win32, Win64",
+      "template": "default"
+    },
+    {
+      "compiler": "XE4",
+      "platforms": "Win32, Win64",
+      "template": "default"
+    },
+    {
+      "compiler": "XE5",
+      "platforms": "Win32, Win64",
+      "template": "default"
+    },
+    {
+      "compiler": "XE6",
+      "platforms": "Win32, Win64",
+      "template": "default"
+    },
+    {
+      "compiler": "XE7",
+      "platforms": "Win32, Win64",
+      "template": "default"
+    },
+    {
+      "compiler": "XE8",
+      "platforms": "Win32, Win64",
+      "template": "default"
+    },
+    {
+      "compiler": "10.0",
+      "platforms": "Win32, Win64",
+      "template": "default"
+    },
+    {
+      "compiler": "10.1",
+      "platforms": "Win32, Win64",
+      "template": "default"
+    },
+    {
+      "compiler": "10.2",
+      "platforms": "Win32, Win64,Linux",
+      "template": "default"
+    },
+    {
+      "compiler": "10.3",
+      "platforms": "Win32, Win64,Linux",
+      "template": "default"
+    }
+  ],
+  "templates": [
+    {
+      "name": "default",
+      "source": [
+        {
+          "src": "source\\JsonDataObjects.pas",
+          "flatten": true,
+          "dest": "src"
+        }
+      ],
+      "searchPaths": [
+        {
+          "path": "src"
+        }
+      ]
+    }
+  ]
+}

--- a/ahausladen.JsonDataObjects.dspec
+++ b/ahausladen.JsonDataObjects.dspec
@@ -64,7 +64,12 @@
       "compiler": "10.3",
       "platforms": "Win32, Win64,Linux",
       "template": "default"
-    }
+    },
+    {
+      "compiler": "10.4",
+      "platforms": "Win32, Win64,Linux",
+      "template": "default"
+    }    
   ],
   "templates": [
     {


### PR DESCRIPTION
Added a dspec file for creating [dpm packages](https://github.com/vincentparrett/DPM)

To create the packages, after downloading dpm.exe (from the release tab on the above link( and adding it to your path), run (from the jsondataobjects folder)

````cli
dpm pack ahausladen.JsonDataObjects.dspec -o=c:\yourdpmsource 
````
Since we don't yet have a central repository for packages, the recommended way to distribute them is to create a release on github and upload the dpkg files as assets on the release. 

Why am I doing this? Well I use jsondataobjects in dpm itself (and will be using it in other projects soon too), so trying to bootstrap it ;)   