### PR TITLE
Fixes UInt64 to Double conversion on ARM64

### DIFF
--- a/Source/JsonDataObjects.pas
+++ b/Source/JsonDataObjects.pas
@@ -7215,6 +7215,19 @@ begin
   end;
 end;
 
+// 32-bit ARM64 emulation fix: Manual digit-by-digit conversion
+// Both UInt64/Double division AND UInt64->Double implicit conversion fail
+function U64ToDouble(u: UInt64): Double;
+const
+  TWO32: Double = 4294967296.0;
+var
+  hi, lo: Cardinal;
+begin
+  hi := Cardinal(u shr 32);
+  lo := Cardinal(u);
+  Result := hi * TWO32 + lo;
+end;
+
 procedure TUtf8JsonReader.LexNumber(P: PByte{$IFDEF CPUARM}; EndP: PByte{$ENDIF});
 var
   F: PByte;
@@ -7337,7 +7350,7 @@ begin
       EndInt64P := EndP;
     while (P < EndInt64P) and (P^ in [Ord('0')..Ord('9')]) do
       Inc(P);
-    Value := Value + ParseUInt64Utf8(F, P) / Power10[P - F];
+    Value := Value + U64ToDouble(ParseUInt64Utf8(F, P)) / Power10[P - F];
 
     // "Double" can't handle that many digits
     while (P < EndP) and (P^ in [Ord('0')..Ord('9')]) do
@@ -7868,7 +7881,7 @@ begin
       EndInt64P := EndP;
     while (P < EndInt64P) and (P^ in ['0'..'9']) do
       Inc(P);
-    Value := Value + ParseUInt64(F, P) / Power10[P - F];
+    Value := Value + U64ToDouble(ParseUInt64(F, P)) / Power10[P - F];
 
     // "Double" can't handle that many digits
     while (P < EndP) and (P^ in ['0'..'9']) do


### PR DESCRIPTION
Addresses an issue where direct UInt64 to Double conversion, as well as division operations involving UInt64, were failing on 32-bit ARM64 emulation.

Implements a workaround by manually converting UInt64 to Double in two parts (hi and lo Cardinal) to avoid the failing operations. This ensures correct parsing of large numbers.

https://github.com/danieleteti/delphimvcframework/pull/865

More about the bug in general.

https://en.delphipraxis.net/topic/14678-critical-bug-report-delphi-13-32-bit-rtl-failures-on-windows-arm64-emulation